### PR TITLE
Add unit and integration test coverage

### DIFF
--- a/VisionaryAnalytics.Api/Program.cs
+++ b/VisionaryAnalytics.Api/Program.cs
@@ -43,3 +43,5 @@ app.MapControllers();
 app.MapHub<HubProcessamento>("/hubs/processamento");
 
 app.Run();
+
+public partial class Program { }

--- a/VisionaryAnalytics.sln
+++ b/VisionaryAnalytics.sln
@@ -18,6 +18,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisionaryAnalytics.FrameWor
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisionaryAnalytics.VideoWorker", "VisionaryAnalytics.VideoWorker\VisionaryAnalytics.VideoWorker.csproj", "{FD33658F-FE0D-A106-B45C-BC8299D7BB71}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisionaryAnalytics.Application.Tests", "tests\\VisionaryAnalytics.Application.Tests\\VisionaryAnalytics.Application.Tests.csproj", "{06253A53-823F-49BC-A840-25AC49F11422}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisionaryAnalytics.Api.IntegrationTests", "tests\\VisionaryAnalytics.Api.IntegrationTests\\VisionaryAnalytics.Api.IntegrationTests.csproj", "{AD0213F8-1AA4-4D17-A76E-7EDB3CA01C81}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,10 +49,18 @@ Global
 		{9E313669-D8DA-4CE8-9593-9C1D693F10E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9E313669-D8DA-4CE8-9593-9C1D693F10E1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FD33658F-FE0D-A106-B45C-BC8299D7BB71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FD33658F-FE0D-A106-B45C-BC8299D7BB71}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FD33658F-FE0D-A106-B45C-BC8299D7BB71}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FD33658F-FE0D-A106-B45C-BC8299D7BB71}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {FD33658F-FE0D-A106-B45C-BC8299D7BB71}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {FD33658F-FE0D-A106-B45C-BC8299D7BB71}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {FD33658F-FE0D-A106-B45C-BC8299D7BB71}.Release|Any CPU.Build.0 = Release|Any CPU
+                {06253A53-823F-49BC-A840-25AC49F11422}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {06253A53-823F-49BC-A840-25AC49F11422}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {06253A53-823F-49BC-A840-25AC49F11422}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {06253A53-823F-49BC-A840-25AC49F11422}.Release|Any CPU.Build.0 = Release|Any CPU
+                {AD0213F8-1AA4-4D17-A76E-7EDB3CA01C81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {AD0213F8-1AA4-4D17-A76E-7EDB3CA01C81}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {AD0213F8-1AA4-4D17-A76E-7EDB3CA01C81}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {AD0213F8-1AA4-4D17-A76E-7EDB3CA01C81}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/tests/VisionaryAnalytics.Api.IntegrationTests/Controllers/VideoControllerTests.cs
+++ b/tests/VisionaryAnalytics.Api.IntegrationTests/Controllers/VideoControllerTests.cs
@@ -1,0 +1,120 @@
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using VisionaryAnalytics.Application.DTOs;
+using VisionaryAnalytics.Domain.VOs;
+
+namespace VisionaryAnalytics.Api.IntegrationTests.Controllers;
+
+public class VideoControllerTests
+{
+    [Fact]
+    public async Task ObterStatus_DeveRetornarNotFound_QuandoServicoFalhar()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        factory.VideoJobServiceMock
+            .Setup(s => s.ObterStatusAsync("123"))
+            .ReturnsAsync(Resultado<string>.Falha("erro"));
+
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/videos/123/status");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var payload = await response.Content.ReadAsStringAsync();
+        payload.Should().Contain("erro");
+    }
+
+    [Fact]
+    public async Task ObterStatus_DeveRetornarOk_QuandoServicoForBemSucedido()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        factory.VideoJobServiceMock
+            .Setup(s => s.ObterStatusAsync("123"))
+            .ReturnsAsync(Resultado<string>.Ok(value: "Processando"));
+
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/videos/123/status");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonDocument>();
+        body!.RootElement.GetProperty("Status").GetString().Should().Be("Processando");
+    }
+
+    [Fact]
+    public async Task ObterResultados_DeveRetornarNotFound_QuandoServicoFalhar()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        factory.VideoJobServiceMock
+            .Setup(s => s.ObterResultadosAsync("123"))
+            .ReturnsAsync(Resultado<List<QrCode>>.Falha("erro"));
+
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/videos/123/resultados");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ObterResultados_DeveRetornarOkComConteudo_QuandoServicoForBemSucedido()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        var resultados = new List<QrCode>
+        {
+            new(TimeSpan.FromSeconds(1), "conteudo-1"),
+            new(TimeSpan.FromSeconds(2), "conteudo-2")
+        };
+        factory.VideoJobServiceMock
+            .Setup(s => s.ObterResultadosAsync("123"))
+            .ReturnsAsync(Resultado<List<QrCode>>.Ok(value: resultados));
+
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/videos/123/resultados");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonDocument>();
+        var lista = body!.RootElement.GetProperty("Resultados").EnumerateArray().Select(e => e.GetProperty("Conteudo").GetString()).ToList();
+        lista.Should().BeEquivalentTo(new[] { "conteudo-1", "conteudo-2" });
+    }
+
+    [Fact]
+    public async Task Enviar_DeveRetornarBadRequest_QuandoArquivoNaoFornecido()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync("/api/videos/enviar", new MultipartFormDataContent());
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Enviar_DeveRetornarAccepted_QuandoProcessamentoForCriado()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        factory.VideoJobServiceMock
+            .Setup(s => s.CriarJobAsync(It.IsAny<Stream>(), "video.mp4", ".mp4", "video/mp4", 3))
+            .ReturnsAsync(Resultado<string>.Ok(value: "abc"));
+
+        using var client = factory.CreateClient();
+
+        await using var fileStream = new MemoryStream([1, 2, 3]);
+        using var content = new MultipartFormDataContent();
+        var fileContent = new StreamContent(fileStream);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("video/mp4");
+        content.Add(fileContent, "arquivo", "video.mp4");
+
+        var response = await client.PostAsync("/api/videos/enviar", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var body = await response.Content.ReadFromJsonAsync<JsonDocument>();
+        body!.RootElement.GetProperty("Id").GetString().Should().Be("abc");
+    }
+}

--- a/tests/VisionaryAnalytics.Api.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/tests/VisionaryAnalytics.Api.IntegrationTests/CustomWebApplicationFactory.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
+using VisionaryAnalytics.Application.Interfaces;
+
+namespace VisionaryAnalytics.Api.IntegrationTests;
+
+public class CustomWebApplicationFactory : WebApplicationFactory<Program>
+{
+    public Mock<IVideoJobService> VideoJobServiceMock { get; } = new();
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll<IVideoJobService>();
+            services.AddSingleton(VideoJobServiceMock.Object);
+        });
+    }
+}

--- a/tests/VisionaryAnalytics.Api.IntegrationTests/VisionaryAnalytics.Api.IntegrationTests.csproj
+++ b/tests/VisionaryAnalytics.Api.IntegrationTests/VisionaryAnalytics.Api.IntegrationTests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.8" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\VisionaryAnalytics.Api\VisionaryAnalytics.Api.csproj" />
+    <ProjectReference Include="..\..\VisionaryAnalytics.Application\VisionaryAnalytics.Application.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/VisionaryAnalytics.Application.Tests/Services/VideoJobServiceTests.cs
+++ b/tests/VisionaryAnalytics.Application.Tests/Services/VideoJobServiceTests.cs
@@ -1,0 +1,162 @@
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using VisionaryAnalytics.Application.Configuration;
+using VisionaryAnalytics.Application.DTOs;
+using VisionaryAnalytics.Application.Interfaces;
+using VisionaryAnalytics.Application.Services;
+using VisionaryAnalytics.Domain.Entities;
+using VisionaryAnalytics.Domain.Enums;
+using VisionaryAnalytics.Domain.Interfaces.Repositories;
+using VisionaryAnalytics.Domain.VOs;
+
+namespace VisionaryAnalytics.Application.Tests.Services;
+
+public class VideoJobServiceTests
+{
+    private readonly Mock<IValidadorArquivoService> _validadorArquivoServiceMock = new();
+    private readonly Mock<IArmazenamentoArquivoService> _armazenamentoArquivoServiceMock = new();
+    private readonly Mock<IVideoJobRepository> _videoJobRepositoryMock = new();
+    private readonly Mock<IProdutorMessageBroker> _produtorMock = new();
+    private readonly IOptions<RabbitMQOptions> _rabbitOptions = Options.Create(new RabbitMQOptions
+    {
+        HostName = "localhost",
+        UserName = "guest",
+        Password = "guest",
+        Queues = new RabbitMQQueues
+        {
+            ExtrairFrames = "extrair-frames",
+            ProcessarFrames = "processar-frames"
+        }
+    });
+
+    private VideoJobService CriarServico()
+    {
+        return new VideoJobService(
+            _validadorArquivoServiceMock.Object,
+            _armazenamentoArquivoServiceMock.Object,
+            _videoJobRepositoryMock.Object,
+            _produtorMock.Object,
+            _rabbitOptions);
+    }
+
+    [Fact]
+    public async Task CriarJobAsync_DeveRetornarFalha_QuandoValidacaoFalhar()
+    {
+        _validadorArquivoServiceMock
+            .Setup(s => s.Validar("video.mp4", ".mp4", 1024))
+            .Returns(Resultado<string>.Falha("erro"));
+
+        using var stream = new MemoryStream([1, 2, 3]);
+        var servico = CriarServico();
+
+        var resultado = await servico.CriarJobAsync(stream, "video.mp4", ".mp4", "video/mp4", 1024);
+
+        resultado.Sucesso.Should().BeFalse();
+        resultado.Mensagem.Should().Be("erro");
+        _armazenamentoArquivoServiceMock.Verify(s => s.SalvarAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _videoJobRepositoryMock.Verify(r => r.CriarAsync(It.IsAny<VideoJob>()), Times.Never);
+        _produtorMock.Verify(p => p.ProduzirAsync(It.IsAny<VideoJob>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CriarJobAsync_DeveCriarJobEPublicarMensagem_QuandoValidacaoTiverSucesso()
+    {
+        _validadorArquivoServiceMock
+            .Setup(s => s.Validar("video.mp4", ".mp4", 1024))
+            .Returns(Resultado<string>.Ok());
+
+        _armazenamentoArquivoServiceMock
+            .Setup(s => s.SalvarAsync(It.IsAny<Stream>(), "video.mp4", ".mp4"))
+            .ReturnsAsync("armazenado.mp4");
+
+        VideoJob? jobPersistido = null;
+        _videoJobRepositoryMock
+            .Setup(r => r.CriarAsync(It.IsAny<VideoJob>()))
+            .Callback<VideoJob>(job => jobPersistido = job)
+            .Returns(Task.CompletedTask);
+
+        _produtorMock
+            .Setup(p => p.ProduzirAsync(It.IsAny<VideoJob>(), _rabbitOptions.Value.Queues.ExtrairFrames, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        using var stream = new MemoryStream([1, 2, 3]);
+        var servico = CriarServico();
+
+        var resultado = await servico.CriarJobAsync(stream, "video.mp4", ".mp4", "video/mp4", 1024);
+
+        resultado.Sucesso.Should().BeTrue();
+        resultado.Value.Should().NotBeNullOrWhiteSpace();
+
+        jobPersistido.Should().NotBeNull();
+        jobPersistido!.Id.Should().Be(resultado.Value);
+        jobPersistido.NomeOriginalArquivo.Should().Be("video.mp4");
+        jobPersistido.NomeArmazenadoArquivo.Should().Be("armazenado.mp4");
+        jobPersistido.Status.Should().Be(Status.NaFila);
+
+        _armazenamentoArquivoServiceMock.Verify(s => s.SalvarAsync(It.IsAny<Stream>(), "video.mp4", ".mp4"), Times.Once);
+        _videoJobRepositoryMock.Verify(r => r.CriarAsync(It.IsAny<VideoJob>()), Times.Once);
+        _produtorMock.Verify(p => p.ProduzirAsync(It.IsAny<VideoJob>(), _rabbitOptions.Value.Queues.ExtrairFrames, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ObterStatusAsync_DeveRetornarFalha_QuandoJobNaoExistir()
+    {
+        const string id = "123";
+        _videoJobRepositoryMock.Setup(r => r.ObterPorIdAsync(id)).ReturnsAsync((VideoJob?)null);
+        var servico = CriarServico();
+
+        var resultado = await servico.ObterStatusAsync(id);
+
+        resultado.Sucesso.Should().BeFalse();
+        resultado.Mensagem.Should().Contain(id);
+    }
+
+    [Fact]
+    public async Task ObterStatusAsync_DeveRetornarStatusFormatado_QuandoJobExistir()
+    {
+        var job = VideoJob.Criar("video.mp4", "armazenado.mp4");
+        job.IniciarProcessamento();
+
+        _videoJobRepositoryMock.Setup(r => r.ObterPorIdAsync(job.Id)).ReturnsAsync(job);
+        var servico = CriarServico();
+
+        var resultado = await servico.ObterStatusAsync(job.Id);
+
+        resultado.Sucesso.Should().BeTrue();
+        resultado.Value.Should().Be("Processando");
+    }
+
+    [Fact]
+    public async Task ObterResultadosAsync_DeveRetornarFalha_QuandoJobNaoExistir()
+    {
+        const string id = "123";
+        _videoJobRepositoryMock.Setup(r => r.ObterPorIdAsync(id)).ReturnsAsync((VideoJob?)null);
+        var servico = CriarServico();
+
+        var resultado = await servico.ObterResultadosAsync(id);
+
+        resultado.Sucesso.Should().BeFalse();
+        resultado.Mensagem.Should().Contain(id);
+    }
+
+    [Fact]
+    public async Task ObterResultadosAsync_DeveRetornarListaDeQrCodes_QuandoJobExistir()
+    {
+        var job = VideoJob.Criar("video.mp4", "armazenado.mp4");
+        var resultados = new List<QrCode>
+        {
+            new(TimeSpan.FromSeconds(1), "conteudo-1"),
+            new(TimeSpan.FromSeconds(2), "conteudo-2")
+        };
+        job.ConcluirProcessamento(resultados);
+
+        _videoJobRepositoryMock.Setup(r => r.ObterPorIdAsync(job.Id)).ReturnsAsync(job);
+        var servico = CriarServico();
+
+        var resultado = await servico.ObterResultadosAsync(job.Id);
+
+        resultado.Sucesso.Should().BeTrue();
+        resultado.Value.Should().BeEquivalentTo(resultados);
+    }
+}

--- a/tests/VisionaryAnalytics.Application.Tests/VisionaryAnalytics.Application.Tests.csproj
+++ b/tests/VisionaryAnalytics.Application.Tests/VisionaryAnalytics.Application.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\VisionaryAnalytics.Application\VisionaryAnalytics.Application.csproj" />
+    <ProjectReference Include="..\..\VisionaryAnalytics.Domain\VisionaryAnalytics.Domain.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add unit test project that validates VideoJobService behaviour for creation, status and results flows
- add integration test project that exercises the VideoController endpoints with a mocked service
- register the new test projects in the solution and expose the Program class for WebApplicationFactory